### PR TITLE
tweak(cache): extends cache object from null, avoid the prototype noise

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 function memoize(fn) {
-  let cache = {}
+  let cache = Object.create(null)
   return function(...args) {
     if (JSON.stringify(args) in cache) return cache[JSON.stringify(args)]
     return cache[JSON.stringify(args)] = fn.apply(fn, args)


### PR DESCRIPTION
if you use `in` to judge whether a key is in the cache, be sure the key is not in prototype.

like: 

```
var args = 'args'
Object.prototype[JSON.stringify([args])] = 'fake value'

var a = function (a) { console.log(a) }
var b = memoize(a)

b(args)

```

I'm sure it will return the fake value when I have set it on Object prototype.

another way to avoid it I think is to use `Object.hasOwnProperty` to judge the key is whether in the cache. GOOD LUCK to you.